### PR TITLE
Ubuntu installation: download piku-nginx.* before copying

### DIFF
--- a/docs/install/INSTALL-ubuntu-18.04-bionic.md
+++ b/docs/install/INSTALL-ubuntu-18.04-bionic.md
@@ -54,6 +54,9 @@ include /home/PAAS_USERNAME/.piku/nginx/*.conf;
 ## Set up systemd.path to reload nginx upon config changes
 
 ```bash
+# Grab the configuration files
+wget https://raw.githubusercontent.com/piku/piku/master/piku-nginx.path
+wget https://raw.githubusercontent.com/piku/piku/master/piku-nginx.service
 # Set up systemd.path to reload nginx upon config changes
 sudo cp ./piku-nginx.{path, service} /etc/systemd/system/
 sudo systemctl enable piku-nginx.{path,service}

--- a/docs/install/INSTALL-ubuntu-22.04-jammy.md
+++ b/docs/install/INSTALL-ubuntu-22.04-jammy.md
@@ -54,6 +54,9 @@ include /home/PAAS_USERNAME/.piku/nginx/*.conf;
 ## Set up systemd.path to reload nginx upon config changes
 
 ```bash
+# Grab the configuration files
+wget https://raw.githubusercontent.com/piku/piku/master/piku-nginx.path
+wget https://raw.githubusercontent.com/piku/piku/master/piku-nginx.service
 # Set up systemd.path to reload nginx upon config changes
 sudo cp ./piku-nginx.{path, service} /etc/systemd/system/
 sudo systemctl enable piku-nginx.{path,service}


### PR DESCRIPTION
`INSTALL-ubuntu-16.04.md` has instructions to download `piku-nginx.{path, service}` before copying:

```bash
wget https://raw.githubusercontent.com/piku/piku/master/piku-nginx.path
wget https://raw.githubusercontent.com/piku/piku/master/piku-nginx.service
```

But `INSTALL-ubuntu-18.04-bionic.md` and `INSTALL-ubuntu-22.04-jammy.md` do not.
The installation fails because of that.

Adding these instructions.