### PR TITLE
Add minimal instructions to install acme.sh

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -100,6 +100,10 @@ command="FINGERPRINT=85:29:07:cb:de:ad:be:ef:42:65:00:c8:d2:6b:9e:ff NAME=defaul
 
 This line is what enables you to `ssh` (and perform `git` over `ssh` operations) to the `piku` user without a password, verifying your identity via your public key, restricting what can be done remotely and passing on to `piku` itself the commands you'll be issuing.
 
+### Install acme.sh
+
+To get SSL certificates, piku uses [acme.sh](https://github.com/acmesh-official/acme.sh). To install it, become the piku user (`sudo su - $PAAS_USERNAME`) and then follow the [installation instructions](https://github.com/acmesh-official/acme.sh?tab=readme-ov-file#1-how-to-install).
+
 ### Test
 
 From your machine, do:


### PR DESCRIPTION
The recommended instructions changed since I wrote the issue. To prevent the documentation from going stale, I reference the official install instructions rather than including specific steps in piku's docs.

Closes https://github.com/piku/piku/issues/389#issuecomment-2646743401